### PR TITLE
Updated Manifest.json

### DIFF
--- a/custom_components/eskom_loadshedding/manifest.json
+++ b/custom_components/eskom_loadshedding/manifest.json
@@ -5,6 +5,7 @@
   "issue_tracker": "https://github.com/swartjean/ha-eskom-loadshedding/issues",  
   "dependencies": [],
   "config_flow": true,
+  "version": "1.0.2",
   "codeowners": [
     "@swartjean"
   ],


### PR DESCRIPTION
Update the manifest to include a version key as per requirement for home assistant core version 2021.3.X

https://github.com/home-assistant/core/pull/45919