### PR TITLE
Update entity.py

### DIFF
--- a/custom_components/eskom_loadshedding/entity.py
+++ b/custom_components/eskom_loadshedding/entity.py
@@ -34,7 +34,7 @@ class EskomEntity(entity.Entity):
         }
 
     @property
-    def device_state_attributes(self):
+    def extra_state_attributes(self):
         """Return the state attributes."""
         return {
             "stage": self.coordinator.data.get("stage"),


### PR DESCRIPTION
device_state_attributes -> extra_state_attributes name change

device_state_attribute has been deprecated, Home Assistant started to complain in the logs about it, changed the files on my end and worked fine.
