### PR TITLE
Add polling to calendar entities (#24)

### DIFF
--- a/custom_components/eskom_loadshedding/const.py
+++ b/custom_components/eskom_loadshedding/const.py
@@ -25,6 +25,7 @@ CONF_SCAN_PERIOD = "scan_period"
 # Defaults
 DEFAULT_SCAN_PERIOD = 7200
 MIN_SCAN_PERIOD = 1800
+DEFAULT_CALENDAR_SCAN_PERIOD = 30
 
 # Entity Identifiers
 LOCAL_EVENTS_ID = "calendar_local_events"


### PR DESCRIPTION
This fixes #24.

Calendar entities should now update their state to reflect the current loadshedding event within 30 seconds of the event starting.