### PR TITLE
Fix async_add_job and async_forward_entry_setup deprecation

### DIFF
--- a/custom_components/eskom_loadshedding/__init__.py
+++ b/custom_components/eskom_loadshedding/__init__.py
@@ -56,12 +56,7 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry):
 
     hass.data[DOMAIN][entry.entry_id] = coordinator
 
-    for platform in PLATFORMS:
-        if entry.options.get(platform, True):
-            coordinator.platforms.append(platform)
-            hass.async_add_job(
-                hass.config_entries.async_forward_entry_setup(entry, platform)
-            )
+    hass.config_entries.async_forward_entry_setups(entry, PLATFORMS)
 
     if not entry.update_listeners:
         entry.add_update_listener(async_reload_entry)


### PR DESCRIPTION
Fix for deprecated functions introduced in HASS 2024.7.0
`async_add_job` and `async_forward_entry_setup`