### PR TITLE
Fix deprecated alias config

### DIFF
--- a/custom_components/eskom_loadshedding/__init__.py
+++ b/custom_components/eskom_loadshedding/__init__.py
@@ -9,7 +9,8 @@ from datetime import timedelta
 import logging
 
 from homeassistant.config_entries import ConfigEntry
-from homeassistant.core import Config, HomeAssistant
+from homeassistant.core import HomeAssistant
+from homeassistant.core_config import Config
 from homeassistant.exceptions import ConfigEntryNotReady
 from homeassistant.helpers.aiohttp_client import async_get_clientsession
 from homeassistant.helpers.update_coordinator import DataUpdateCoordinator, UpdateFailed


### PR DESCRIPTION
Fixes a deprecation warning in HASS 2024.11.xx
(Alias config will be deprecated in 2025)